### PR TITLE
Migrate to new/valid repositories (V8 3.14-s390)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -294,5 +294,4 @@ $(ENVFILE).new:
 # Dependencies.
 # Remember to keep these in sync with the DEPS file.
 dependencies:
-	svn checkout --force http://gyp.googlecode.com/svn/trunk build/gyp \
-	    --revision 1501
+	git clone https://chromium.googlesource.com/external/gyp build/gyp


### PR DESCRIPTION
Few of the repositories in the Makefile are no longer valid and seems to have migrated to new location. Updating to make use of new and valid repositories.
